### PR TITLE
Support audio mixing on background audio

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.1",
+  "version": "1.0.2",
   "name": "nl.kingsquare.cordova.background-audio",
   "description": "\n\t\tBackground Audio for iOS\n\n\t\tWhen included within a cordova/phonegap build then the application will support background audio for iOS\n\t\tout of the box. No further action is necessary.\n\n\t\tThis negates having to use location/other solutions that may not be accepted by Apple.\n\t",
   "license": "MIT",

--- a/src/ios/BackgroundAudio.m
+++ b/src/ios/BackgroundAudio.m
@@ -8,14 +8,16 @@
 @implementation BackgroundAudio
 
 - (void)pluginInitialize {
-	// initializations go here.
-	AVAudioSession *audioSession = [AVAudioSession sharedInstance];
-	BOOL ok;
-	NSError *setCategoryError = nil;
-	ok = [audioSession setCategory:AVAudioSessionCategoryPlayback error:&setCategoryError];
-	if (!ok) {
-		NSLog(@"%s setCategoryError=%@", __PRETTY_FUNCTION__, setCategoryError);
-	}
+    // initializations go here.
+    AVAudioSession *audioSession = [AVAudioSession sharedInstance];
+    BOOL ok;
+    NSError *setCategoryError = nil;
+    ok = [audioSession setCategory:AVAudioSessionCategoryPlayback
+                       withOptions:AVAudioSessionCategoryOptionMixWithOthers
+                             error:&setCategoryError];
+    if (!ok) {
+        NSLog(@"%s setCategoryError=%@", __PRETTY_FUNCTION__, setCategoryError);
+    }
 }
 
 @end


### PR DESCRIPTION
This adds the audio mixing option, which is [available from iOS 6](https://developer.apple.com/library/prerelease/ios/documentation/AVFoundation/Reference/AVAudioSession_ClassReference/index.html#//apple_ref/c/tdef/AVAudioSessionCategoryOptions).
